### PR TITLE
[Feat] S3 이미지 업로드 & 업로드 취소 API 구현 & 도메인 연관관계 설정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 	// Swagger 의존성 추가
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	// AWS S3 의존성 추가
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 
 	tasks.named('test') {
 		useJUnitPlatform()

--- a/src/main/java/com/example/HiBuddy/domain/comment/Comments.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/Comments.java
@@ -1,22 +1,27 @@
-package com.example.HiBuddy.domain.scrab;
+package com.example.HiBuddy.domain.comment;
 
 import com.example.HiBuddy.domain.post.Posts;
 import com.example.HiBuddy.domain.user.Users;
 import com.example.HiBuddy.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "scrabs")
-public class Scrabs extends BaseEntity {
+public class Comments extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
+
+    @Column(length = 500)
+    private String comment;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -25,5 +30,4 @@ public class Scrabs extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Posts post;
-
 }

--- a/src/main/java/com/example/HiBuddy/domain/comment/CommentsRepository.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/CommentsRepository.java
@@ -1,0 +1,6 @@
+package com.example.HiBuddy.domain.comment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentsRepository extends JpaRepository<Comments, Long> {
+}

--- a/src/main/java/com/example/HiBuddy/domain/image/Images.java
+++ b/src/main/java/com/example/HiBuddy/domain/image/Images.java
@@ -1,4 +1,37 @@
 package com.example.HiBuddy.domain.image;
 
-public class Images {
+import com.example.HiBuddy.domain.post.Posts;
+import com.example.HiBuddy.domain.user.Users;
+import com.example.HiBuddy.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Images extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String type;
+
+    @Column(nullable = false)
+    private String url;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Posts post;
 }

--- a/src/main/java/com/example/HiBuddy/domain/image/ImagesController.java
+++ b/src/main/java/com/example/HiBuddy/domain/image/ImagesController.java
@@ -1,0 +1,51 @@
+package com.example.HiBuddy.domain.image;
+
+import com.example.HiBuddy.domain.image.dto.response.ImagesResponseDto;
+import com.example.HiBuddy.domain.user.UsersService;
+import com.example.HiBuddy.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/images")
+public class ImagesController {
+    private final ImagesService imagesService;
+    private final UsersService usersService;
+
+    @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "S3 이미지 업로드 API", description = "ImagesResponseDto 사용")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "IMAGE401", description = "이미지 업로드 실패", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<ImagesResponseDto> uploadImages(@AuthenticationPrincipal UserDetails user, @RequestParam("fileList") List<MultipartFile> fileList) {
+        Long userId = usersService.getUserId(user);
+        List<Images> imageList = imagesService.uploadImages(fileList, userId);
+        ImagesResponseDto imagesResponseDto = ImagesConverter.toUploadImagesDto(imageList);
+        return ApiResponse.onSuccess(imagesResponseDto);
+    }
+
+    @DeleteMapping("/{imageId}")
+    @Operation(summary = "S3 이미지 업로드 취소 API", description = "dto 사용 x")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "IMAGE401"),
+    })
+    public ApiResponse<Void> deleteImage(@PathVariable Long imageId) {
+        imagesService.deleteImages(imageId);
+        return ApiResponse.onSuccess(null);
+    }
+
+
+}

--- a/src/main/java/com/example/HiBuddy/domain/image/ImagesConverter.java
+++ b/src/main/java/com/example/HiBuddy/domain/image/ImagesConverter.java
@@ -1,0 +1,16 @@
+package com.example.HiBuddy.domain.image;
+
+import com.example.HiBuddy.domain.image.dto.response.ImagesResponseDto;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ImagesConverter {
+
+    public static ImagesResponseDto toUploadImagesDto(List<Images> imagesList) {
+        List<Long> imageIds = imagesList.stream().map(Images::getId).collect(Collectors.toList());
+        return new ImagesResponseDto(imageIds);
+    }
+}

--- a/src/main/java/com/example/HiBuddy/domain/image/ImagesRepository.java
+++ b/src/main/java/com/example/HiBuddy/domain/image/ImagesRepository.java
@@ -1,0 +1,8 @@
+package com.example.HiBuddy.domain.image;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImagesRepository extends JpaRepository<Images, Long> {
+}

--- a/src/main/java/com/example/HiBuddy/domain/image/ImagesService.java
+++ b/src/main/java/com/example/HiBuddy/domain/image/ImagesService.java
@@ -1,0 +1,56 @@
+package com.example.HiBuddy.domain.image;
+
+import com.example.HiBuddy.domain.user.Users;
+import com.example.HiBuddy.domain.user.UsersRepository;
+import com.example.HiBuddy.global.response.code.resultCode.ErrorStatus;
+import com.example.HiBuddy.global.response.exception.handler.ImagesHandler;
+import com.example.HiBuddy.global.response.exception.handler.UsersHandler;
+import com.example.HiBuddy.global.s3.S3Service;
+import com.example.HiBuddy.global.s3.dto.S3Result;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ImagesService {
+    private final ImagesRepository imagesRepository;
+    private final UsersRepository usersRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public List<Images> uploadImages(List<MultipartFile> fileList, Long userId) {
+        Users user = usersRepository.findById(userId).orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+
+        List<Images> savedImages = new ArrayList<>();
+        for(MultipartFile file : fileList) {
+            S3Result s3Result = s3Service.uploadFile(file);
+
+            Images newImages = new Images();
+            newImages.setName(file.getOriginalFilename());
+            newImages.setUrl(s3Result.getFileUrl());
+            newImages.setType(file.getContentType());
+            newImages.setUser(user);
+
+            savedImages.add(imagesRepository.save(newImages));
+        }
+
+        return savedImages;
+    }
+
+    @Transactional
+    public void deleteImages(Long imageId) {
+        Images image = imagesRepository.findById(imageId).orElseThrow(() -> new ImagesHandler(ErrorStatus.IMAGE_NOT_FOUND));
+        String imageUrl = image.getUrl();
+        String fileName = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+
+        s3Service.deleteFile(fileName);
+        imagesRepository.delete(image);
+
+    }
+}

--- a/src/main/java/com/example/HiBuddy/domain/image/dto/response/ImagesResponseDto.java
+++ b/src/main/java/com/example/HiBuddy/domain/image/dto/response/ImagesResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.HiBuddy.domain.image.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImagesResponseDto {
+    public List<Long> imageIds;
+}

--- a/src/main/java/com/example/HiBuddy/domain/oauth/google/GoogleService.java
+++ b/src/main/java/com/example/HiBuddy/domain/oauth/google/GoogleService.java
@@ -6,7 +6,6 @@ import com.example.HiBuddy.domain.oauth.jwt.refreshtoken.RefreshToken;
 import com.example.HiBuddy.domain.oauth.jwt.refreshtoken.RefreshTokenRepository;
 import com.example.HiBuddy.domain.user.Users;
 import com.example.HiBuddy.domain.user.UsersRepository;
-import com.example.HiBuddy.domain.user.UsersRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/example/HiBuddy/domain/oauth/google/GoogleTokenResponse.java
+++ b/src/main/java/com/example/HiBuddy/domain/oauth/google/GoogleTokenResponse.java
@@ -5,6 +5,7 @@ import lombok.Data;
 @Data
 public class GoogleTokenResponse {
     private String access_token;
+    private String refresh_token;
     private String token_type;
     private Long expires_in;
     private String id_token;

--- a/src/main/java/com/example/HiBuddy/domain/oauth/jwt/JwtFilter.java
+++ b/src/main/java/com/example/HiBuddy/domain/oauth/jwt/JwtFilter.java
@@ -1,7 +1,6 @@
 package com.example.HiBuddy.domain.oauth.jwt;
 
 import com.example.HiBuddy.domain.user.Users;
-import com.example.HiBuddy.domain.user.UsersRequestDto;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -14,7 +13,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {

--- a/src/main/java/com/example/HiBuddy/domain/post/Posts.java
+++ b/src/main/java/com/example/HiBuddy/domain/post/Posts.java
@@ -1,4 +1,49 @@
 package com.example.HiBuddy.domain.post;
 
-public class Posts {
+import com.example.HiBuddy.domain.image.Images;
+import com.example.HiBuddy.domain.postLike.PostLikes;
+import com.example.HiBuddy.domain.scrab.Scrabs;
+import com.example.HiBuddy.domain.user.Users;
+import com.example.HiBuddy.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "posts")
+public class Posts extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "title", length = 100)
+    private String title;
+
+    @Column(name = "content", length = 500, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean isAuthor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users user;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Images> postImageList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<PostLikes> postLikeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Scrabs> scrabList = new ArrayList<>();
 }

--- a/src/main/java/com/example/HiBuddy/domain/post/PostsRepository.java
+++ b/src/main/java/com/example/HiBuddy/domain/post/PostsRepository.java
@@ -1,0 +1,8 @@
+package com.example.HiBuddy.domain.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostsRepository extends JpaRepository<Posts, Long> {
+}

--- a/src/main/java/com/example/HiBuddy/domain/postLike/PostLikes.java
+++ b/src/main/java/com/example/HiBuddy/domain/postLike/PostLikes.java
@@ -1,4 +1,4 @@
-package com.example.HiBuddy.domain.scrab;
+package com.example.HiBuddy.domain.postLike;
 
 import com.example.HiBuddy.domain.post.Posts;
 import com.example.HiBuddy.domain.user.Users;
@@ -9,13 +9,12 @@ import lombok.*;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "scrabs")
-public class Scrabs extends BaseEntity {
+@NoArgsConstructor
+@Table(name = "post_likes")
+public class PostLikes extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -25,5 +24,4 @@ public class Scrabs extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Posts post;
-
 }

--- a/src/main/java/com/example/HiBuddy/domain/postLike/PostLikesRepository.java
+++ b/src/main/java/com/example/HiBuddy/domain/postLike/PostLikesRepository.java
@@ -1,0 +1,6 @@
+package com.example.HiBuddy.domain.postLike;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikesRepository  extends JpaRepository<PostLikes, Long> {
+}

--- a/src/main/java/com/example/HiBuddy/domain/postLike/postLikes.java
+++ b/src/main/java/com/example/HiBuddy/domain/postLike/postLikes.java
@@ -1,4 +1,0 @@
-package com.example.HiBuddy.domain.postLike;
-
-public class postLikes {
-}

--- a/src/main/java/com/example/HiBuddy/domain/scrab/ScrabsRepository.java
+++ b/src/main/java/com/example/HiBuddy/domain/scrab/ScrabsRepository.java
@@ -1,0 +1,6 @@
+package com.example.HiBuddy.domain.scrab;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScrabsRepository extends JpaRepository<Scrabs, Long> {
+}

--- a/src/main/java/com/example/HiBuddy/domain/user/Status.java
+++ b/src/main/java/com/example/HiBuddy/domain/user/Status.java
@@ -1,0 +1,12 @@
+package com.example.HiBuddy.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Status {
+    ENABLED,  // 활성화(default)
+    DISABLED, // 비활성화 (장기 미접속자)
+    DELETED;  // 삭제
+}

--- a/src/main/java/com/example/HiBuddy/domain/user/Users.java
+++ b/src/main/java/com/example/HiBuddy/domain/user/Users.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class Users extends BaseEntity implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(unique = true, nullable = false)
+    @Column(name = "id", unique = true, nullable = false)
     private Long id;
 
     @Column

--- a/src/main/java/com/example/HiBuddy/domain/user/UsersController.java
+++ b/src/main/java/com/example/HiBuddy/domain/user/UsersController.java
@@ -1,5 +1,6 @@
 package com.example.HiBuddy.domain.user;
 
+import com.example.HiBuddy.domain.user.dto.request.UsersRequestDto;
 import com.example.HiBuddy.global.response.ApiResponse;
 import com.example.HiBuddy.global.response.code.resultCode.ErrorStatus;
 import com.example.HiBuddy.global.response.code.resultCode.SuccessStatus;
@@ -7,16 +8,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/java/com/example/HiBuddy/domain/user/UsersService.java
+++ b/src/main/java/com/example/HiBuddy/domain/user/UsersService.java
@@ -1,24 +1,14 @@
 package com.example.HiBuddy.domain.user;
 
+import com.example.HiBuddy.domain.user.dto.request.UsersRequestDto;
 import com.example.HiBuddy.global.response.code.resultCode.ErrorStatus;
 import com.example.HiBuddy.global.response.exception.handler.UsersHandler;
 import com.example.HiBuddy.global.security.UserDetailsImpl;
-import com.example.HiBuddy.global.security.UserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import lombok.RequiredArgsConstructor;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -55,6 +45,14 @@ public class UsersService {
         usersRepository.save(users);
 
         return dto;
+    }
+
+    @Transactional
+    public Long getUserId(UserDetails user) {
+        String username = user.getUsername();
+        Users users = usersRepository.findByUsername(username)
+                .orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        return users.getId();
     }
 }
 

--- a/src/main/java/com/example/HiBuddy/domain/user/dto/request/UsersRequestDto.java
+++ b/src/main/java/com/example/HiBuddy/domain/user/dto/request/UsersRequestDto.java
@@ -1,5 +1,6 @@
-package com.example.HiBuddy.domain.user;
+package com.example.HiBuddy.domain.user.dto.request;
 
+import com.example.HiBuddy.domain.user.Country;
 import lombok.*;
 
 public class UsersRequestDto {

--- a/src/main/java/com/example/HiBuddy/domain/user/dto/response/UsersResponseDto.java
+++ b/src/main/java/com/example/HiBuddy/domain/user/dto/response/UsersResponseDto.java
@@ -1,5 +1,6 @@
-package com.example.HiBuddy.domain.user;
+package com.example.HiBuddy.domain.user.dto.response;
 
+import com.example.HiBuddy.domain.user.Country;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/example/HiBuddy/global/response/exception/handler/ImagesHandler.java
+++ b/src/main/java/com/example/HiBuddy/global/response/exception/handler/ImagesHandler.java
@@ -1,0 +1,10 @@
+package com.example.HiBuddy.global.response.exception.handler;
+
+import com.example.HiBuddy.global.response.code.BaseErrorCode;
+import com.example.HiBuddy.global.response.exception.GeneralException;
+
+public class ImagesHandler extends GeneralException {
+    public ImagesHandler(BaseErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/HiBuddy/global/s3/S3Config.java
+++ b/src/main/java/com/example/HiBuddy/global/s3/S3Config.java
@@ -1,0 +1,30 @@
+package com.example.HiBuddy.global.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/example/HiBuddy/global/s3/S3Service.java
+++ b/src/main/java/com/example/HiBuddy/global/s3/S3Service.java
@@ -1,0 +1,68 @@
+package com.example.HiBuddy.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.example.HiBuddy.global.s3.dto.S3Result;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.objectUrl}")
+    private String fileUrl;
+
+    private final AmazonS3Client amazonS3Client;
+
+    private String getFileExtension(String fileName) { // 파일 이름에서 파일 확장자를 추출하는 메서드
+        try {
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일(" + fileName + ") 입니다.");
+        }
+    }
+
+    // UUID.randomUUID().toString() 을 사용하여 파일명을 고유하게 만듦. 동시에 여러 파일이 업로드 되는 상황에서 파일 이름 충돌을 방지
+    private String createFileName(String fileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    }
+
+    public S3Result uploadFile(MultipartFile file) {
+        String fileName = createFileName(file.getOriginalFilename());
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(file.getContentType());
+
+        try (InputStream inputStream = file.getInputStream()) {
+            String bucketPath = "hibuddy-bucket/" + fileName;
+            amazonS3Client.putObject(new PutObjectRequest(bucket, bucketPath, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
+        }
+
+        return new S3Result(fileUrl + "/HiBuddy/" + fileName);
+    }
+
+    public void deleteFile(String fileName) {
+        try {
+            String bucketPath = "hibuddy-bucket/" + fileName;
+            amazonS3Client.deleteObject(bucket, bucketPath);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/example/HiBuddy/global/s3/dto/S3Result.java
+++ b/src/main/java/com/example/HiBuddy/global/s3/dto/S3Result.java
@@ -1,0 +1,12 @@
+package com.example.HiBuddy.global.s3.dto;
+
+import lombok.Getter;
+
+@Getter
+public class S3Result {
+    private String fileUrl;
+
+    public S3Result(String fileUrl) {
+        this.fileUrl = fileUrl;
+    }
+}


### PR DESCRIPTION
# 구현내용
- S3 config 관련 코드를 구현하고, s3이미지 업로드와 업로드를 취소하는 API를 구현했습니다.
- 스레드 관련 엔티티의 연관관계를 설정했습니다. 

