### PR TITLE
[Feat] 스레드 CRUD 구현 

### DIFF
--- a/src/main/java/com/example/HiBuddy/domain/comment/Comments.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/Comments.java
@@ -4,24 +4,26 @@ import com.example.HiBuddy.domain.post.Posts;
 import com.example.HiBuddy.domain.user.Users;
 import com.example.HiBuddy.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(name = "comments")
 public class Comments extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
 
-    @Column(length = 500)
+    @Column(nullable = false, length = 500)
     private String comment;
+
+    @Column(columnDefinition = "boolean default false")
+    private boolean isAuthor;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/example/HiBuddy/domain/comment/CommentsController.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/CommentsController.java
@@ -1,0 +1,99 @@
+package com.example.HiBuddy.domain.comment;
+
+import com.example.HiBuddy.domain.comment.dto.request.CommentsRequestDto;
+import com.example.HiBuddy.domain.comment.dto.response.CommentsResponseDto;
+import com.example.HiBuddy.domain.user.UsersService;
+import com.example.HiBuddy.global.response.ApiResponse;
+import com.example.HiBuddy.global.response.code.resultCode.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/thread/posts/{postId}/comments")
+public class CommentsController {
+
+    private final UsersService usersService;
+    private final CommentsService commnetsService;
+
+    @PostMapping
+    @Operation(summary = "댓글 생성 API", description = "댓글 생성. CreateCommentsRequestDto 사용")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENTS401", description = "댓글 생성에 실패했습니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENTS402", description = "이미 작성한 댓글입니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENT405", description = "댓글은 최대 500자까지 입력 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+    })
+    public ApiResponse<CommentsResponseDto.CommentDto> createComment(@AuthenticationPrincipal UserDetails user, @PathVariable Long postId, @RequestBody CommentsRequestDto.CreateCommentRequestDto request) {
+        CommentsResponseDto.CommentDto response = commnetsService.createComment(usersService.getUserId(user), postId, request);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "댓글 조회 API", description = "게시글당 1페이지에 최대 10개의 댓글을 조회하는 기능. 게시글은 생성날짜 기준으로 오름차순 정렬")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENTS403", description = "존재하지 않는 댓글입니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+    })
+    public ApiResponse<CommentsResponseDto.CommentsInfoPageDto> getCommnetsInfoResultOnPage(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int limit,
+            @RequestParam(defaultValue = "created_at.asc") String sort) {
+        int pageNumber = page - 1;
+
+        CommentsResponseDto.CommentsInfoPageDto commentsInfoPageDto =
+                commnetsService.getCommentsInfoResultsOnPage(pageNumber, limit);
+
+        return ApiResponse.onSuccess(commentsInfoPageDto);
+    }
+
+
+    @PatchMapping("/{commentId}")
+    @Operation(summary = "댓글 수정 API", description = "댓글 수정, UpdateCommentsRequestDto 사용")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENTS403", description = "존재하지 않는 댓글입니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENTS404", description = "해당 댓글에 대한 권한이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENT405", description = "댓글은 최대 500자까지 입력 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+            @Parameter(name = "commentId", description = "댓글의 id"),
+    })
+    public ApiResponse<SuccessStatus> updateComment(@AuthenticationPrincipal UserDetails user, @PathVariable Long postId, @PathVariable Long commentId, @RequestBody CommentsRequestDto.UpdateCommentRequestDto request) {
+        commnetsService.updateComment(usersService.getUserId(user), postId, commentId, request);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    @DeleteMapping("/{commentId}")
+    @Operation(summary = "댓글 삭제 API", description = "댓글 id를 받아 해당하는 댓글 삭제")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENTS403", description = "존재하지 않는 댓글입니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENTS404", description = "해당 댓글에 대한 권한이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+            @Parameter(name = "commentId", description = "댓글의 id"),
+    })
+    public ApiResponse<SuccessStatus> deleteComment(@AuthenticationPrincipal UserDetails user, @PathVariable Long postId, @PathVariable Long commentId) {
+        commnetsService.deleteComment(usersService.getUserId(user), commentId);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+}

--- a/src/main/java/com/example/HiBuddy/domain/comment/CommentsConverter.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/CommentsConverter.java
@@ -1,0 +1,55 @@
+package com.example.HiBuddy.domain.comment;
+
+import com.example.HiBuddy.domain.comment.dto.request.CommentsRequestDto;
+import com.example.HiBuddy.domain.comment.dto.response.CommentsResponseDto;
+import com.example.HiBuddy.domain.post.Posts;
+import com.example.HiBuddy.domain.user.Users;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CommentsConverter {
+
+    public static CommentsResponseDto.UserDto toUserDto(Users user) {
+        return CommentsResponseDto.UserDto.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileUrl(user.getProfileImageUrl())
+                .build();
+    }
+
+    public static Comments toCommentEntity(Users user, Posts post, CommentsRequestDto.CreateCommentRequestDto request) {
+        return Comments.builder()
+                .comment(request.getComment())
+                .user(user)
+                .post(post)
+                .build();
+    }
+
+    public static CommentsResponseDto.CommentDto toCommentInfoResultDto(Comments comment, Posts post, Users user, String createdAt) {
+        CommentsResponseDto.UserDto userDto = toUserDto(post.getUser());
+
+        return CommentsResponseDto.CommentDto.builder()
+                .commentId(comment.getId())
+                .comment(comment.getComment())
+                .isAuthor(true)
+                .user(userDto)
+                .createdAt(createdAt)
+                .build();
+    }
+
+    public static CommentsResponseDto.CommentsInfoPageDto toCommentsInfoResultPageDto(List<CommentsResponseDto.CommentDto> commentInfoDtoList, int totalPages, int totalElements,
+                                                                                       boolean isFirst, boolean isLast, int size, int number, int numberOfElements) {
+        return CommentsResponseDto.CommentsInfoPageDto.builder()
+                .result(commentInfoDtoList)
+                .totalPages(totalPages)
+                .totalElements(totalElements)
+                .isFirst(isFirst)
+                .isLast(isLast)
+                .size(size)
+                .number(number)
+                .numberOfElements(numberOfElements)
+                .build();
+    }
+}

--- a/src/main/java/com/example/HiBuddy/domain/comment/CommentsRepository.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/CommentsRepository.java
@@ -1,6 +1,9 @@
 package com.example.HiBuddy.domain.comment;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
+    Page<Comments> findByPostId(Long postId, Pageable pageable);
 }

--- a/src/main/java/com/example/HiBuddy/domain/comment/CommentsService.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/CommentsService.java
@@ -1,0 +1,136 @@
+package com.example.HiBuddy.domain.comment;
+
+import com.example.HiBuddy.domain.comment.dto.request.CommentsRequestDto;
+import com.example.HiBuddy.domain.comment.dto.response.CommentsResponseDto;
+import com.example.HiBuddy.domain.post.Posts;
+import com.example.HiBuddy.domain.post.PostsRepository;
+import com.example.HiBuddy.domain.user.Users;
+import com.example.HiBuddy.domain.user.UsersRepository;
+import com.example.HiBuddy.global.response.code.resultCode.ErrorStatus;
+import com.example.HiBuddy.global.response.exception.handler.CommentsHandler;
+import com.example.HiBuddy.global.response.exception.handler.PostsHandler;
+import com.example.HiBuddy.global.response.exception.handler.UsersHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentsService {
+
+    private final UsersRepository usersRepository;
+    private final PostsRepository postsRepository;
+    private final CommentsRepository commentsRepository;
+
+    public String getCreatedAt(LocalDateTime createdAt) {
+
+        // 서버시간을 UTC로 설정
+        ZoneId serverZone = ZoneId.systemDefault(); // 시스템 기본 시간대를 사용
+        LocalDateTime now = ZonedDateTime.now(serverZone).toLocalDateTime();
+
+        Duration duration = Duration.between(createdAt, now);
+
+        long seconds = duration.getSeconds();
+        long minutes = duration.toMinutes();
+        long hours = duration.toHours();
+        long days = duration.toDays();
+
+        if (minutes < 1) {
+            return seconds + "s ago";
+        } else if (minutes < 60) {
+            return minutes + "m ago";
+        } else if (hours < 24) {
+            return hours + "h ago";
+        } else {
+            return days + "d ago";
+        }
+    }
+
+    // 댓글 생성 API
+    @Transactional
+    public CommentsResponseDto.CommentDto createComment(Long userId, Long postId, CommentsRequestDto.CreateCommentRequestDto request) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        Posts post = postsRepository.findById(postId)
+                .orElseThrow(() -> new PostsHandler(ErrorStatus.POST_NOT_FOUND));
+
+        if (request.getComment().length() > 500) {
+            throw new CommentsHandler(ErrorStatus.COMMENT_MAX_LENGTH_500);
+        }
+
+        Comments newComment = CommentsConverter.toCommentEntity(user, post, request);
+        commentsRepository.save(newComment);
+
+        return CommentsConverter.toCommentInfoResultDto(newComment, post, user, newComment.getCreatedAt().toString());
+    }
+
+    // 댓글 조회 API
+    @Transactional(readOnly = true)
+    public CommentsResponseDto.CommentsInfoPageDto getCommentsInfoResultsOnPage(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
+        Page<Comments> commentsPage = commentsRepository.findAll(pageRequest);
+
+        List<CommentsResponseDto.CommentDto> commentInfoDtoList = commentsPage.getContent().stream()
+                .map(comment -> {
+                    Users user = comment.getUser();
+                    Posts post = comment.getPost();
+                    String createdAt = getCreatedAt(comment.getCreatedAt());
+                    return CommentsConverter.toCommentInfoResultDto(comment, post, user, createdAt);
+                })
+                .collect(Collectors.toList());
+
+        return CommentsConverter.toCommentsInfoResultPageDto(commentInfoDtoList, commentsPage.getTotalPages(),
+                (int) commentsPage.getTotalElements(), commentsPage.isFirst(), commentsPage.isLast(),
+                commentsPage.getSize(), commentsPage.getNumber(), commentsPage.getNumberOfElements());
+
+    }
+
+    // 댓글 수정 API
+    @Transactional
+    public void updateComment(Long userId, Long postId, Long commentId, CommentsRequestDto.UpdateCommentRequestDto request) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        Comments comment = commentsRepository.findById(commentId)
+                .orElseThrow(() -> new CommentsHandler(ErrorStatus.COMMENT_NOT_FOUND));
+
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new CommentsHandler(ErrorStatus.COMMENT_NOT_AUTHORIZED);
+        }
+
+        if (comment.getComment().length() > 500) {
+            throw new CommentsHandler(ErrorStatus.COMMENT_MAX_LENGTH_500);
+        }
+
+        comment.setComment(request.getComment());
+
+        Posts post = comment.getPost();
+
+        commentsRepository.save(comment);
+    }
+
+    // 댓글 삭제 API
+    @Transactional
+    public void deleteComment(Long userId, Long commentId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        Comments comment = commentsRepository.findById(commentId)
+                .orElseThrow(() -> new CommentsHandler(ErrorStatus.COMMENT_NOT_FOUND));
+
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new CommentsHandler(ErrorStatus.COMMENT_NOT_AUTHORIZED);
+        }
+
+        commentsRepository.deleteById(comment.getId());
+    }
+}

--- a/src/main/java/com/example/HiBuddy/domain/comment/dto/request/CommentsRequestDto.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/dto/request/CommentsRequestDto.java
@@ -1,0 +1,30 @@
+package com.example.HiBuddy.domain.comment.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CommentsRequestDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateCommentRequestDto {
+
+        @Size(max = 500, message = "댓글은 최대 1,000자까지 입력 가능합니다.")
+        private String comment;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateCommentRequestDto {
+
+        @Size(max = 500, message = "댓글은 최대 1,000자까지 입력 가능합니다.")
+        private String comment;
+    }
+}

--- a/src/main/java/com/example/HiBuddy/domain/comment/dto/response/CommentsResponseDto.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/dto/response/CommentsResponseDto.java
@@ -1,0 +1,48 @@
+package com.example.HiBuddy.domain.comment.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class CommentsResponseDto {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserDto {
+        private Long userId;
+        private String nickname;
+        private String profileUrl;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CommentDto {
+        private Long commentId;
+        private String comment;
+        private boolean isAuthor;
+        private String createdAt;
+        private UserDto user;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentsInfoPageDto {
+        private List<CommentDto> result;
+        private int totalPages;
+        private int totalElements;
+        private boolean isFirst;
+        private boolean isLast;
+        private int size;
+        private int number;
+        private int numberOfElements;
+    }
+}

--- a/src/main/java/com/example/HiBuddy/domain/image/Images.java
+++ b/src/main/java/com/example/HiBuddy/domain/image/Images.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@Table(name = "images")
 public class Images extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/HiBuddy/domain/image/ImagesController.java
+++ b/src/main/java/com/example/HiBuddy/domain/image/ImagesController.java
@@ -29,7 +29,7 @@ public class ImagesController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "IMAGE401", description = "이미지 업로드 실패", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
-    public ApiResponse<ImagesResponseDto> uploadImages(@AuthenticationPrincipal UserDetails user, @RequestParam("fileList") List<MultipartFile> fileList) {
+    public ApiResponse<ImagesResponseDto> uploadImages(@AuthenticationPrincipal UserDetails user, @RequestPart("fileList") List<MultipartFile> fileList) {
         Long userId = usersService.getUserId(user);
         List<Images> imageList = imagesService.uploadImages(fileList, userId);
         ImagesResponseDto imagesResponseDto = ImagesConverter.toUploadImagesDto(imageList);

--- a/src/main/java/com/example/HiBuddy/domain/oauth/jwt/token/TokenServiceImpl.java
+++ b/src/main/java/com/example/HiBuddy/domain/oauth/jwt/token/TokenServiceImpl.java
@@ -61,7 +61,7 @@ public class TokenServiceImpl implements TokenService {
             return ApiResponse.onFailure(ErrorStatus.USER_NOT_FOUND.getCode(), ErrorStatus.USER_NOT_FOUND.getMessage(), null);
         }
 
-        String newAccess = jwtUtil.createJwt("Authorization", username, user.getId(), 600000L);
+        String newAccess = jwtUtil.createJwt("Authorization", username, user.getId(), 60000000L);
         String newRefresh = jwtUtil.createJwt("refresh_token", username, user.getId(), 86400000L);
 
         // Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장

--- a/src/main/java/com/example/HiBuddy/domain/post/Posts.java
+++ b/src/main/java/com/example/HiBuddy/domain/post/Posts.java
@@ -1,10 +1,13 @@
 package com.example.HiBuddy.domain.post;
 
+import com.example.HiBuddy.domain.comment.Comments;
 import com.example.HiBuddy.domain.image.Images;
 import com.example.HiBuddy.domain.postLike.PostLikes;
-import com.example.HiBuddy.domain.scrab.Scrabs;
+import com.example.HiBuddy.domain.scrap.Scraps;
 import com.example.HiBuddy.domain.user.Users;
 import com.example.HiBuddy.global.entity.BaseEntity;
+import com.example.HiBuddy.global.response.code.resultCode.ErrorStatus;
+import com.example.HiBuddy.global.response.exception.handler.PostLikesHandler;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -25,10 +28,10 @@ public class Posts extends BaseEntity {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "title", length = 100)
+    @Column(name = "title", length = 100, nullable = false)
     private String title;
 
-    @Column(name = "content", length = 500, columnDefinition = "TEXT")
+    @Column(name = "content", length = 500, columnDefinition = "TEXT", nullable = false)
     private String content;
 
     @Column(columnDefinition = "boolean default false")
@@ -45,5 +48,23 @@ public class Posts extends BaseEntity {
     private List<PostLikes> postLikeList = new ArrayList<>();
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<Scrabs> scrabList = new ArrayList<>();
+    private List<Scraps> scrapsList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Comments> commentsList = new ArrayList<>();
+
+    @Column(name = "like_num")
+    private Integer likeNum;
+
+    public void incrementLikeNum() {
+        this.likeNum++;
+    }
+
+    public void decrementLikeNum() {
+        if (this.likeNum > 0) {
+            this.likeNum--;
+        } else {
+            throw new PostLikesHandler(ErrorStatus.POSTLIKE_NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/com/example/HiBuddy/domain/post/PostsController.java
+++ b/src/main/java/com/example/HiBuddy/domain/post/PostsController.java
@@ -1,0 +1,212 @@
+package com.example.HiBuddy.domain.post;
+
+import com.example.HiBuddy.domain.post.dto.request.PostsRequestDto;
+import com.example.HiBuddy.domain.post.dto.response.PostsResponseDto;
+import com.example.HiBuddy.domain.user.Users;
+import com.example.HiBuddy.global.response.ApiResponse;
+import com.example.HiBuddy.domain.user.UsersService;
+import com.example.HiBuddy.global.response.code.resultCode.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/thread")
+public class PostsController {
+
+    private final UsersService usersService;
+    private final PostsService postsService;
+
+    @PostMapping("/posts")
+    @Operation(summary = "게시글 생성 API", description = "게시글을 생성, CreatePostRequestDto 사용")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST402", description = "게시글 작성 실패", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST405", description = "최대 3장의 이미지만 업로드 가능합니다.6", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST408", description = "게시글의 제목은 최대 100자까지 입력 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST409", description = "게시글의 본문은 최대 500자까지 입력 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+    })
+    public ApiResponse<PostsResponseDto.PostsInfoDto> createPost(@AuthenticationPrincipal UserDetails user, @RequestBody PostsRequestDto.CreatePostRequestDto request) {
+        PostsResponseDto.PostsInfoDto post = postsService.createPost(usersService.getUserId(user), request);
+        return ApiResponse.onSuccess(post);
+    }
+
+    @GetMapping("/posts/{postId}")
+    @Operation(summary = "특정 게시글 조회 API", description = "게시글의 id를 이용하여 특정 게시글의 정보 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "존재하지 않는 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+    })
+    public ApiResponse<PostsResponseDto.PostsInfoDto> getPostInfoResult(@AuthenticationPrincipal UserDetails user, @PathVariable(name = "postId") Long postId) {
+
+        PostsResponseDto.PostsInfoDto postsInfoDto = postsService.getPostInfoResult(usersService.getUserId(user), postId);
+        return ApiResponse.onSuccess(postsInfoDto);
+    }
+
+    @PatchMapping("/posts/{postId}")
+    @Operation(summary = "게시글 수정 API", description = "특정 게시글을 수정, UpdatePostRequestDto 사용")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "존재하지 않는 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST407", description = "게시글에 대한 권한이 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+    })
+    public ApiResponse<SuccessStatus> updatePost(@AuthenticationPrincipal Users user, @PathVariable(name = "postId") Long postId, @RequestBody PostsRequestDto.UpdatePostRequestDto request) {
+        postsService.updatePost(usersService.getUserId(user), postId, request);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    @DeleteMapping("/posts/{postId}")
+    @Operation(summary = "게시글 삭제 API", description = "특정 게시글을 삭제")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "존재하지 않는 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST407", description = "게시글에 대한 권한이 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+    })
+    public ApiResponse<SuccessStatus> deletePost(@AuthenticationPrincipal UserDetails user, @PathVariable(name = "postId") Long postId) {
+        postsService.deletePost(usersService.getUserId(user), postId);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    @GetMapping("/main/popular")
+    @Operation(summary = "메인페이지 게시글 3개 조회 API (좋아요 순)", description = "좋아요 수가 많은 게시글 일수록 메인 페이지 상단에 위치, 게시글 3개 조회, MainPageTopThreePostListDto 사용")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "존재하지 않는 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<List<PostsResponseDto.MainPageTopThreePostListDto>> getTopThreePosts() {
+        List<PostsResponseDto.MainPageTopThreePostListDto> mainPageTopThreePostListDto = postsService.getMainPageTopThreePostList();
+        return ApiResponse.onSuccess(mainPageTopThreePostListDto);
+    }
+
+
+    @GetMapping("/posts")
+    @Operation(summary = "게시글 5개씩 조회 API (1페이지당)", description = "페이지 한 개당 최대 5개의 글을 조회 가능. 게시글은 생성된 날짜가 최신일수록 상단에 위치")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "존재하지 않는 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<PostsResponseDto.PostsInfoPageDto> getPostsInfoResultOnPage(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "5") int limit,
+            @RequestParam(defaultValue = "created_at.desc") String sort) {
+        // 페이지 번호는 1부터 시작하도록 설정. Spring Data JPA의 페이지 번호는 0부터 시작하기 때문에 1을 빼줌
+        int pageNumber = page - 1;
+
+        PostsResponseDto.PostsInfoPageDto postsInfoPageDto = postsService.getPostsInfoResultsOnPage(pageNumber, limit);
+
+        return ApiResponse.onSuccess(postsInfoPageDto);
+    }
+
+    @PostMapping("posts/{postId}/likes")
+    @Operation(summary = "좋아요 누르기 API", description = "게시글에 좋아요를 생성하는 기능")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER404", description = "존재하지 않는 유저입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "존재하지 않는 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POSTLIKE401", description = "좋아요 누르기에 실패했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POSTLIKE402", description = "이미 좋아요를 누른 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+    })
+    public ApiResponse<SuccessStatus> addPostLikes(@AuthenticationPrincipal UserDetails user, @PathVariable(name = "postId") Long postId) {
+
+        postsService.addLike(usersService.getUserId(user), postId);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    @DeleteMapping("posts/{postId}/likes")
+    @Operation(summary = "좋아요 해제 API", description = "게시글에 좋아요를 해제하는 기능")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POSTLIKE403", description = "존재하지 않는 좋아요 입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POSTLIKE404", description = "좋아요의 개수가 0개 입니다", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+    })
+    public ApiResponse<SuccessStatus> removePostLike(@AuthenticationPrincipal UserDetails user, @PathVariable(name = "postId") Long postId) {
+
+        postsService.removeLike(usersService.getUserId(user), postId);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    @PostMapping("posts/{postId}/scraps")
+    @Operation(summary = "스크랩 생성 API", description = "게시글을 스크랩하는 기능")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "존재하지 않는 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SCRAP401", description = "스크랩 생성에 실패했습니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SCRAP402", description = "이미 스크랩한 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+    })
+    public ApiResponse<SuccessStatus> createScraps(@AuthenticationPrincipal UserDetails user, @PathVariable(name = "postId") Long postId) {
+        postsService.createScraps(usersService.getUserId(user), postId);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    @DeleteMapping("posts/{postId}/scraps")
+    @Operation(summary = "스크랩 해제 API", description = "게시글을 스크랩 해제하는 기능")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "존재하지 않는 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+    })
+    public ApiResponse<SuccessStatus> deleteScraps(@AuthenticationPrincipal UserDetails user, @PathVariable(name = "postId") Long postId) {
+        postsService.deleteScraps(usersService.getUserId(user), postId);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "게시글 제목으로 검색하기 API", description = "게시글 제목을 기준으로 검색하는 기능")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "존재하지 않는 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SEARCH401", description = "존재하지 않는 게시글 제목입니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+
+    })
+    public ApiResponse<List<PostsResponseDto.PostsInfoDto>> searchPostsByTtile(@RequestParam String keyword) {
+
+        List<PostsResponseDto.PostsInfoDto> postsInfoDtoList = postsService.searchPostByTitle(keyword);
+        return ApiResponse.onSuccess(postsInfoDtoList);
+    }
+
+    @GetMapping("/search/posts/{postId}")
+    @Operation(summary = "검색한 게시글 조회 API", description = "게시글의 id를 이용하여 검색 성공한 특정 게시글의 정보 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "존재하지 않는 게시글입니다.", content = @Content(schema = @Schema(implementation = ApiResponses.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글의 id"),
+    })
+    public ApiResponse<PostsResponseDto.PostsInfoDto> getPostInfoResultBySearch(@AuthenticationPrincipal UserDetails user, @PathVariable(name = "postId") Long postId) {
+
+        PostsResponseDto.PostsInfoDto postsInfoDto = postsService.getPostInfoResult(usersService.getUserId(user), postId);
+        return ApiResponse.onSuccess(postsInfoDto);
+    }
+
+}

--- a/src/main/java/com/example/HiBuddy/domain/post/PostsConverter.java
+++ b/src/main/java/com/example/HiBuddy/domain/post/PostsConverter.java
@@ -1,0 +1,89 @@
+package com.example.HiBuddy.domain.post;
+
+import com.example.HiBuddy.domain.image.Images;
+import com.example.HiBuddy.domain.post.dto.request.PostsRequestDto;
+import com.example.HiBuddy.domain.post.dto.response.PostsResponseDto;
+import com.example.HiBuddy.domain.user.Users;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class PostsConverter {
+
+    public static PostsResponseDto.ImageDto toImageDto(Images image) {
+        return PostsResponseDto.ImageDto.builder()
+                .imageId(image.getId())
+                .imageUrl(image.getUrl())
+                .build();
+    }
+
+    public static PostsResponseDto.UserDto toUserDto(Users user) {
+        return PostsResponseDto.UserDto.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileUrl(user.getProfileImageUrl())
+                .build();
+
+    }
+
+    public static Posts toPostsEntity(Users user, PostsRequestDto.CreatePostRequestDto postsEntityDto) {
+        return Posts.builder()
+                .user(user)
+                .title(postsEntityDto.getTitle())
+                .content(postsEntityDto.getContent())
+                .postImageList(new ArrayList<>())
+                .postLikeList(new ArrayList<>())
+                .scrapsList(new ArrayList<>())
+                .commentsList(new ArrayList<>())
+                .build();
+    }
+
+    public static PostsResponseDto.PostsInfoDto toPostInfoResultDto(Posts post, Users user, boolean checkLike, boolean checkScrap, String createdAt) {
+        PostsResponseDto.UserDto userDto = toUserDto(post.getUser());
+
+        List<PostsResponseDto.ImageDto> imageListDto = post.getPostImageList().stream()
+                .map(PostsConverter::toImageDto).collect(Collectors.toList());
+
+        return PostsResponseDto.PostsInfoDto.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .likeNum(post.getPostLikeList().size())
+                .commentNum(post.getCommentsList().size())
+                .checkLike(checkLike)
+                .checkScrap(checkScrap)
+                .isAuthor(true)
+                .user(userDto)
+                .postImages(imageListDto)
+                .createdAt(createdAt)
+                .build();
+    }
+
+    public static PostsResponseDto.MainPageTopThreePostListDto mainPageTopThreePostListDto(Posts post) {
+        return PostsResponseDto.MainPageTopThreePostListDto.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .likeNum(post.getPostLikeList().size())
+                .commentNum(post.getCommentsList().size())
+                .build();
+    }
+
+    public static PostsResponseDto.PostsInfoPageDto toPostInfoResultPageDto(List<PostsResponseDto.PostsInfoDto> postsInfoDtoList, int totalPages, int totalElements,
+                                                                            boolean isFirst, boolean isLast, int size, int number, int numberOfElements) {
+
+        return PostsResponseDto.PostsInfoPageDto.builder()
+                .result(postsInfoDtoList)
+                .totalPages(totalPages)
+                .totalElements(totalElements)
+                .isFirst(isFirst)
+                .isLast(isLast)
+                .size(size)
+                .number(number)
+                .numberOfElements(numberOfElements)
+                .build();
+
+    }
+}

--- a/src/main/java/com/example/HiBuddy/domain/post/PostsRepository.java
+++ b/src/main/java/com/example/HiBuddy/domain/post/PostsRepository.java
@@ -1,8 +1,22 @@
 package com.example.HiBuddy.domain.post;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostsRepository extends JpaRepository<Posts, Long> {
+
+    Optional<Posts> findByUserIdAndId(Long userId, Long postId);
+
+    @Query("SELECT p FROM Posts p LEFT JOIN p.postLikeList l GROUP BY p ORDER BY COUNT(l) DESC")
+    List<Posts> findTopThreePosts(Pageable pageable);
+
+    @Query("SELECT p FROM Posts p WHERE p.title LIKE %:keyword%")
+    List<Posts> findByTitleContaining(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/example/HiBuddy/domain/post/PostsService.java
+++ b/src/main/java/com/example/HiBuddy/domain/post/PostsService.java
@@ -1,0 +1,304 @@
+package com.example.HiBuddy.domain.post;
+
+import com.example.HiBuddy.domain.image.Images;
+import com.example.HiBuddy.domain.image.ImagesRepository;
+import com.example.HiBuddy.domain.post.dto.request.PostsRequestDto;
+import com.example.HiBuddy.domain.post.dto.response.PostsResponseDto;
+import com.example.HiBuddy.domain.postLike.PostLikes;
+import com.example.HiBuddy.domain.postLike.PostLikesRepository;
+import com.example.HiBuddy.domain.scrap.Scraps;
+import com.example.HiBuddy.domain.scrap.ScrapsRepository;
+import com.example.HiBuddy.domain.user.Users;
+import com.example.HiBuddy.domain.user.UsersRepository;
+import com.example.HiBuddy.global.response.ApiResponse;
+import com.example.HiBuddy.global.response.code.resultCode.ErrorStatus;
+import com.example.HiBuddy.global.response.code.resultCode.SuccessStatus;
+import com.example.HiBuddy.global.response.exception.handler.PostLikesHandler;
+import com.example.HiBuddy.global.response.exception.handler.PostsHandler;
+import com.example.HiBuddy.global.response.exception.handler.ScrapsHandler;
+import com.example.HiBuddy.global.response.exception.handler.UsersHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostsService {
+
+    private final ImagesRepository imagesRepository;
+    private final UsersRepository usersRepository;
+    private final PostsRepository postsRepository;
+    private final PostLikesRepository postLikesRepository;
+    private final ScrapsRepository scrapsRepository;
+
+    // 시간 구하는 메서드
+    public String getCreatedAt(LocalDateTime createdAt) {
+
+        // 서버시간을 UTC로 설정
+        ZoneId serverZone = ZoneId.systemDefault(); // 시스템 기본 시간대를 사용
+        LocalDateTime now = ZonedDateTime.now(serverZone).toLocalDateTime();
+
+        Duration duration = Duration.between(createdAt, now);
+
+        long seconds = duration.getSeconds();
+        long minutes = duration.toMinutes();
+        long hours = duration.toHours();
+        long days = duration.toDays();
+
+        if (minutes < 1) {
+            return seconds + "s ago";
+        } else if (minutes < 60) {
+            return minutes + "m ago";
+        } else if (hours < 24) {
+            return hours + "h ago";
+        } else {
+            return days + "d ago";
+        }
+    }
+
+    // 게시글 생성 메서드
+    @Transactional
+    public PostsResponseDto.PostsInfoDto createPost(Long userId, PostsRequestDto.CreatePostRequestDto request) {
+        if (request.getImageIds().size() > 3) {
+            throw new PostsHandler(ErrorStatus.POST_IMAGE_LIMIT_EXCEEDED);
+        }
+
+        if (request.getTitle().length() > 100) {
+            throw new PostsHandler(ErrorStatus.POST_TITLE_MAX_LENGTH_100);
+        }
+
+        if (request.getContent().length() > 500) {
+            throw new PostsHandler(ErrorStatus.POST_CONTENT_MAX_LENGTH_500);
+        }
+
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+
+        Posts newPost = PostsConverter.toPostsEntity(user, request);
+        postsRepository.save(newPost);
+
+        // Images 엔티티의 post 필드 설정
+        List<Images> images = imagesRepository.findAllById(request.getImageIds());
+        for (Images image : images) {
+            image.setPost(newPost);
+            imagesRepository.save(image);
+        }
+
+        newPost.getPostImageList().addAll(images); // 양방향 연관관계 설정
+
+        return PostsConverter.toPostInfoResultDto(newPost, user, false, false, newPost.getCreatedAt().toString());
+    }
+
+    // 특정 게시글 조회 메서드
+    @Transactional(readOnly = true)
+    public PostsResponseDto.PostsInfoDto getPostInfoResult(Long userId, Long postId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        Posts post = postsRepository.findById(postId)
+                .orElseThrow(() -> new PostsHandler(ErrorStatus.POST_NOT_FOUND));
+
+        boolean checkLike = postLikesRepository.existsByUserAndPost(user, post);
+        boolean checkScrap = scrapsRepository.existsByUserAndPost(user, post);
+
+        String createdAt = getCreatedAt(post.getCreatedAt());
+
+        return PostsConverter.toPostInfoResultDto(post, user, checkLike, checkScrap, createdAt);
+    }
+
+    // 게시글 수정 메서드
+    @Transactional
+    public void updatePost(Long userId, Long postId, PostsRequestDto.UpdatePostRequestDto request) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        Posts post = postsRepository.findById(postId)
+                .orElseThrow(() -> new PostsHandler(ErrorStatus.POST_NOT_FOUND));
+
+        if (request.getTitle().length() > 100) {
+            throw new PostsHandler(ErrorStatus.POST_TITLE_MAX_LENGTH_100);
+        }
+
+        if (request.getContent().length() > 500) {
+            throw new PostsHandler(ErrorStatus.POST_CONTENT_MAX_LENGTH_500);
+        }
+
+        if (!user.getId().equals(post.getUser().getId())) {
+            throw new UsersHandler(ErrorStatus.POST_NOT_AUTHORIZED);
+        }
+
+        post.setTitle(request.getTitle());
+        post.setContent(request.getContent());
+
+        // 기존 이미지 제거 및 새로운 이미지 추가
+        if (request.getImageIds() != null && !request.getImageIds().isEmpty()) {
+            for (Images image : post.getPostImageList()) {
+                image.setPost(null);
+            }
+            post.getPostImageList().clear();
+            postsRepository.save(post); // title과 content를 먼저 저장
+
+            List<Images> images = imagesRepository.findAllById(request.getImageIds());
+            for (Images image : images) {
+                image.setPost(post);
+            }
+            post.getPostImageList().addAll(images);
+        }
+        postsRepository.save(post); // 변경된 내용 저장
+    }
+
+    // 게시글 삭제 메서드
+    @Transactional
+    public void deletePost(Long userId, Long postId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        Posts post = postsRepository.findByUserIdAndId(userId, postId)
+                .orElseThrow(() -> new PostsHandler(ErrorStatus.POST_NOT_FOUND));
+        if (!user.getId().equals(post.getUser().getId())) {
+            throw new UsersHandler(ErrorStatus.POST_NOT_AUTHORIZED);
+        }
+
+        postsRepository.deleteById(post.getId());
+    }
+
+    // 메인페이지 게시글 3개 조회 (좋아요 순) 메서드
+    @Transactional(readOnly = true)
+    public List<PostsResponseDto.MainPageTopThreePostListDto> getMainPageTopThreePostList() {
+        Pageable pageable = PageRequest.of(0, 3);
+        List<Posts> topThreePost = postsRepository.findTopThreePosts(pageable);
+
+        return topThreePost.stream()
+                .map(PostsConverter::mainPageTopThreePostListDto)
+                .collect(Collectors.toList());
+    }
+
+    // 게시글 5개씩 조회 메서드 (페이지당)
+    @Transactional(readOnly = true)
+    public PostsResponseDto.PostsInfoPageDto getPostsInfoResultsOnPage(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Posts> postsPage = postsRepository.findAll(pageRequest);
+
+        List<PostsResponseDto.PostsInfoDto> postsInfoDtoList = postsPage.getContent().stream()
+                .map(post -> {
+                    Users user = post.getUser();
+                    boolean checkLike = postLikesRepository.existsByUserAndPost(user, post);
+                    boolean checkScrap = scrapsRepository.existsByUserAndPost(user, post);
+                    String createdAt = getCreatedAt(post.getCreatedAt());
+
+                    return PostsConverter.toPostInfoResultDto(post, user, checkLike, checkScrap, createdAt);
+
+                })
+                .collect(Collectors.toList());
+
+        return PostsConverter.toPostInfoResultPageDto(postsInfoDtoList, postsPage.getTotalPages(), (int) postsPage.getTotalElements(),
+                postsPage.isFirst(), postsPage.isLast(), postsPage.getSize(), postsPage.getNumber(), postsPage.getNumberOfElements());
+    }
+
+    // 좋아요 생성 메서드
+    @Transactional
+    public ApiResponse<SuccessStatus> addLike(Long userId, Long postId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        Posts post = postsRepository.findById(postId)
+                .orElseThrow(() -> new PostLikesHandler(ErrorStatus.POSTLIKE_NOT_FOUND));
+
+        boolean alreadyLike = postLikesRepository.existsByUserAndPost(user, post);
+        if(alreadyLike) {
+            throw new PostLikesHandler(ErrorStatus.POSTLIKE_ALREADY_EXISTS);
+        }
+        PostLikes postLikes = PostLikes.builder()
+                .user(user)
+                .post(post)
+                .build();
+
+        post.incrementLikeNum();
+        postLikesRepository.save(postLikes);
+        postsRepository.save(post);
+
+        try {
+            return ApiResponse.onSuccess(SuccessStatus._OK);
+        } catch (Exception e) {
+            throw new PostLikesHandler(ErrorStatus.POSTLIKE_CREATE_FAIL);
+        }
+    }
+
+    // 좋아요 해제 메서드
+    @Transactional
+    public void removeLike(Long userId, Long postId) {
+        Posts post = postsRepository.findById(postId)
+                .orElseThrow(() -> new PostLikesHandler(ErrorStatus.POSTLIKE_NOT_FOUND));
+
+        PostLikes postLikes = postLikesRepository.findByPostIdAndUserId(userId, postId)
+                .orElseThrow(() -> new PostLikesHandler(ErrorStatus.POSTLIKE_NOT_FOUND));
+
+        if (post.getLikeNum() == 0) {
+            throw new PostLikesHandler(ErrorStatus.POSTLIKE_DELETE_FAIL);
+        }
+
+        post.decrementLikeNum();
+        postsRepository.save(post);
+        postLikesRepository.delete(postLikes);
+    }
+
+    // 스크랩 생성 메서드
+    @Transactional
+    public ApiResponse<SuccessStatus> createScraps(Long userId, Long postId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        Posts post = postsRepository.findById(postId)
+                .orElseThrow(() -> new PostsHandler(ErrorStatus.POST_NOT_FOUND));
+        boolean alreadyScrap = scrapsRepository.existsByUserAndPost(user, post);
+        if (alreadyScrap) {
+            throw new ScrapsHandler(ErrorStatus.SCRAP_ALREADY_EXISTS);
+        }
+        Scraps newScrap = Scraps.builder()
+                .user(user)
+                .post(post)
+                .build();
+
+        scrapsRepository.save(newScrap);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    // 스크랩 해제 메서드
+    @Transactional
+    public void deleteScraps(Long userId, Long postId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        Posts post = postsRepository.findById(postId)
+                .orElseThrow(() -> new PostsHandler(ErrorStatus.POST_NOT_FOUND));
+
+        Scraps scraps = scrapsRepository.findByUserAndPost(user, post);
+
+        scrapsRepository.delete(scraps);
+
+    }
+
+    // 게시글 제목으로 검색하기 메서드
+    @Transactional(readOnly = true)
+    public List<PostsResponseDto.PostsInfoDto> searchPostByTitle(String keyword) {
+        List<Posts> posts = postsRepository.findByTitleContaining(keyword);
+
+        return posts.stream()
+                .map(post -> {
+                    Users user = post.getUser();
+                    boolean checkLike = postLikesRepository.existsByUserAndPost(user, post);
+                    boolean checkScrap = scrapsRepository.existsByUserAndPost(user, post);
+                    String createdAt = getCreatedAt(post.getCreatedAt());
+
+                    return PostsConverter.toPostInfoResultDto(post, user, checkLike, checkScrap, post.getCreatedAt().toString());
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/HiBuddy/domain/post/dto/request/PostsRequestDto.java
+++ b/src/main/java/com/example/HiBuddy/domain/post/dto/request/PostsRequestDto.java
@@ -1,0 +1,39 @@
+package com.example.HiBuddy.domain.post.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PostsRequestDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreatePostRequestDto {
+
+        @Size(max = 100, message = "게시글의 제목은 최대 100자까지 입력 가능합니다.")
+        private String title;
+        @Size(max = 500, message = "게시글의 본문은 최대 500자까지 입력 가능합니다.")
+        private String content;
+        private List<Long> imageIds = new ArrayList<>();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdatePostRequestDto {
+
+        @Size(max = 100, message = "게시글의 제목은 최대 100자까지 입력 가능합니다.")
+        private String title;
+        @Size(max = 500, message = "게시글의 본문은 최대 500자까지 입력 가능합니다.")
+        private String content;
+        private List<Long> imageIds = new ArrayList<>();
+    }
+}

--- a/src/main/java/com/example/HiBuddy/domain/post/dto/response/PostsResponseDto.java
+++ b/src/main/java/com/example/HiBuddy/domain/post/dto/response/PostsResponseDto.java
@@ -1,0 +1,75 @@
+package com.example.HiBuddy.domain.post.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class PostsResponseDto {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserDto {
+        private Long userId;
+        private String nickname;
+        private String profileUrl;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class ImageDto {
+        private Long imageId;
+        private String imageUrl;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostsInfoDto {
+        private Long postId;
+        private String title;
+        private String content;
+        private String createdAt;
+        private Integer likeNum;
+        private Integer commentNum;
+        private boolean isAuthor;
+        private boolean checkLike;
+        private boolean checkScrap;
+        private UserDto user;
+        private List<ImageDto> postImages;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MainPageTopThreePostListDto {
+        private Long postId;
+        private String title;
+        private Integer likeNum;
+        private Integer commentNum;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostsInfoPageDto {
+        private List<PostsInfoDto> result;
+        private int totalPages;
+        private int totalElements;
+        private boolean isFirst;
+        private boolean isLast;
+        private int size;
+        private int number;
+        private int numberOfElements;
+
+    }
+
+}

--- a/src/main/java/com/example/HiBuddy/domain/postLike/PostLikesRepository.java
+++ b/src/main/java/com/example/HiBuddy/domain/postLike/PostLikesRepository.java
@@ -1,6 +1,15 @@
 package com.example.HiBuddy.domain.postLike;
 
+import com.example.HiBuddy.domain.post.Posts;
+import com.example.HiBuddy.domain.user.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface PostLikesRepository  extends JpaRepository<PostLikes, Long> {
+    Optional<PostLikes> findByPostIdAndUserId(Long userId, Long postId);
+
+    boolean existsByUserAndPost(Users user, Posts post);
 }

--- a/src/main/java/com/example/HiBuddy/domain/scrab/ScrabsRepository.java
+++ b/src/main/java/com/example/HiBuddy/domain/scrab/ScrabsRepository.java
@@ -1,6 +1,0 @@
-package com.example.HiBuddy.domain.scrab;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ScrabsRepository extends JpaRepository<Scrabs, Long> {
-}

--- a/src/main/java/com/example/HiBuddy/domain/scrap/Scraps.java
+++ b/src/main/java/com/example/HiBuddy/domain/scrap/Scraps.java
@@ -1,4 +1,4 @@
-package com.example.HiBuddy.domain.scrab;
+package com.example.HiBuddy.domain.scrap;
 
 import com.example.HiBuddy.domain.post.Posts;
 import com.example.HiBuddy.domain.user.Users;
@@ -11,8 +11,8 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "scrabs")
-public class Scrabs extends BaseEntity {
+@Table(name = "scraps")
+public class Scraps extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")

--- a/src/main/java/com/example/HiBuddy/domain/scrap/ScrapsRepository.java
+++ b/src/main/java/com/example/HiBuddy/domain/scrap/ScrapsRepository.java
@@ -1,0 +1,14 @@
+package com.example.HiBuddy.domain.scrap;
+
+import com.example.HiBuddy.domain.post.Posts;
+import com.example.HiBuddy.domain.user.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScrapsRepository extends JpaRepository<Scraps, Long> {
+
+    Scraps findByUserAndPost(Users user, Posts post);
+
+    boolean existsByUserAndPost(Users user, Posts post);
+}

--- a/src/main/java/com/example/HiBuddy/domain/user/Users.java
+++ b/src/main/java/com/example/HiBuddy/domain/user/Users.java
@@ -19,6 +19,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(name = "users")
 public class Users extends BaseEntity implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/HiBuddy/global/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/com/example/HiBuddy/global/response/code/resultCode/ErrorStatus.java
@@ -4,7 +4,6 @@ import com.example.HiBuddy.global.response.code.BaseErrorCode;
 import com.example.HiBuddy.global.response.code.ErrorReasonDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.hibernate.annotations.DialectOverride;
 import org.springframework.http.HttpStatus;
 
 // Enum Naming Format: {주체}_{이유}
@@ -30,20 +29,32 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_DELETE_FAIL(HttpStatus.BAD_REQUEST, "USER409", "유저 삭제 실패"),
 
     // Posts
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST401", "게시글을 찾을 수 없습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST401", "존재하지 않는 게시글입니다."),
     POST_CREATE_FAIL(HttpStatus.BAD_REQUEST, "POST402", "게시글 작성에 실패했습니다."),
-    POST_SCRAB_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST403", "스크랩 목록을 찾을 수 없습니다."),
+    POST_SCRAP_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST403", "스크랩 목록을 찾을 수 없습니다."),
     POST_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST404", "게시글 목록이 존재하지 않습니다."),
     POST_TITLE_NOT_FOUND(HttpStatus.NOT_FOUND, "POST405", "존재하지 않는 게시글 제목입니다."),
+    POST_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "POST406", "최대 3장의 이미지만 업로드 가능합니다."),
+    POST_NOT_AUTHORIZED(HttpStatus.UNAUTHORIZED, "POST407", "게시글에 대한 권한이 없습니다."),
+    POST_TITLE_MAX_LENGTH_100(HttpStatus.BAD_REQUEST, "POST408", "게시글의 제목은 최대 100자까지 입력 가능합니다."),
+    POST_CONTENT_MAX_LENGTH_500(HttpStatus.BAD_REQUEST, "POST409", "게시글의 본문은 최대 500자까지 입력 가능합니다."),
 
-    // PostLikes
+    // PostsLike
     POSTLIKE_CREATE_FAIL(HttpStatus.NOT_FOUND, "POSTLIKE401", "좋아요 누르기에 실패했습니다."),
     POSTLIKE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "POSTLIKE402", "이미 좋아요를 누른 게시물입니다."),
     POSTLIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "POSTLIKE403", "존재하지 않는 공감입니다."),
+    POSTLIKE_DELETE_FAIL(HttpStatus.NOT_FOUND, "POSTLIKE404", "좋아요의 개수가 0입니다."),
 
     // Comments
     COMMENT_CREATE_FAIL(HttpStatus.NOT_FOUND, "COMMENT401", "댓글 생성에 실패했습니다."),
     COMMENT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "COMMENT402", "이미 작성한 댓글입니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT403", "존재하지 않는 댓글입니다."),
+    COMMENT_NOT_AUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMENT404", "해당 댓글에 대한 권한이 없습니다."),
+    COMMENT_MAX_LENGTH_500(HttpStatus.BAD_REQUEST, "COMMENT405", "댓글은 최대 500자까지 입력 가능합니다."),
+
+    // Scraps
+    SCRAP_CREATE_FAIL(HttpStatus.NOT_FOUND, "SCRAP401", "스크랩 생성에 실패했습니다."),
+    SCRAP_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "SCRAP402", "이미 스크랩한 게시글입니다."),
 
     // Images
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE401", "파일이 존재하지 않습니다."),

--- a/src/main/java/com/example/HiBuddy/global/response/exception/handler/CommentsHandler.java
+++ b/src/main/java/com/example/HiBuddy/global/response/exception/handler/CommentsHandler.java
@@ -1,0 +1,8 @@
+package com.example.HiBuddy.global.response.exception.handler;
+
+import com.example.HiBuddy.global.response.code.BaseErrorCode;
+import com.example.HiBuddy.global.response.exception.GeneralException;
+
+public class CommentsHandler extends GeneralException {
+    public CommentsHandler(BaseErrorCode errorCode) {super(errorCode);}
+}

--- a/src/main/java/com/example/HiBuddy/global/response/exception/handler/PostLikesHandler.java
+++ b/src/main/java/com/example/HiBuddy/global/response/exception/handler/PostLikesHandler.java
@@ -1,0 +1,9 @@
+package com.example.HiBuddy.global.response.exception.handler;
+
+import com.example.HiBuddy.domain.postLike.PostLikesRepository;
+import com.example.HiBuddy.global.response.code.BaseErrorCode;
+import com.example.HiBuddy.global.response.exception.GeneralException;
+
+public class PostLikesHandler extends GeneralException {
+    public PostLikesHandler(BaseErrorCode errorCode) { super(errorCode);}
+}

--- a/src/main/java/com/example/HiBuddy/global/response/exception/handler/PostsHandler.java
+++ b/src/main/java/com/example/HiBuddy/global/response/exception/handler/PostsHandler.java
@@ -1,0 +1,8 @@
+package com.example.HiBuddy.global.response.exception.handler;
+
+import com.example.HiBuddy.global.response.code.BaseErrorCode;
+import com.example.HiBuddy.global.response.exception.GeneralException;
+
+public class PostsHandler extends GeneralException {
+    public PostsHandler(BaseErrorCode errorCode) { super(errorCode);}
+}

--- a/src/main/java/com/example/HiBuddy/global/response/exception/handler/ScrapsHandler.java
+++ b/src/main/java/com/example/HiBuddy/global/response/exception/handler/ScrapsHandler.java
@@ -1,0 +1,9 @@
+package com.example.HiBuddy.global.response.exception.handler;
+
+import com.example.HiBuddy.global.response.code.BaseErrorCode;
+import com.example.HiBuddy.global.response.exception.GeneralException;
+
+public class ScrapsHandler extends GeneralException {
+    public ScrapsHandler(BaseErrorCode errorCode) { super(errorCode);}
+
+}


### PR DESCRIPTION
# 구현 내용
- 스레드 관련 Posts CRUD 기능을 구현했습니다.
- 댓글 관련 CRUD를 구현했습니다.
- 좋아요, 스크랩 생성&해제 기능을 구현했습니다.
- Users, Images 엔티티에 https://github.com/table 어노테이션을 붙여 테이블명 양식을 통일했습니다.
- 핸들러와 에러코드를 추가했습니다.