### PR TITLE
[Hotfix] Swagger 엔드포인트 접속 권한 추가

### DIFF
--- a/src/main/java/com/example/HiBuddy/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/HiBuddy/global/security/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig { // Servlet Container의 SecurityConfig 생성
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/v1/auth/**","/v1/info/**").permitAll()
                         .requestMatchers("/v1/users/**", "/v1/tests/**","/v1/images/**", "/v1/thread/**").authenticated()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().permitAll()
                 )
                 .cors(corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {


### PR DESCRIPTION
# 수정 내용
- Swgger 엔드포인트의 접속을 위해 SecurityConfig 클래스에 requestMatcher를 사용해 해당 엔드포인트로 접속하는 것을 허용했습니다.