### PR TITLE
[fix] 댓글 조회 API 수정 

### DIFF
--- a/src/main/java/com/example/HiBuddy/domain/comment/CommentsController.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/CommentsController.java
@@ -51,13 +51,13 @@ public class CommentsController {
             @Parameter(name = "postId", description = "게시글의 id"),
     })
     public ApiResponse<CommentsResponseDto.CommentsInfoPageDto> getCommnetsInfoResultOnPage(
+            @PathVariable Long postId,
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int limit,
-            @RequestParam(defaultValue = "created_at.asc") String sort) {
+            @RequestParam(defaultValue = "10") int limit) {
         int pageNumber = page - 1;
 
         CommentsResponseDto.CommentsInfoPageDto commentsInfoPageDto =
-                commnetsService.getCommentsInfoResultsOnPage(pageNumber, limit);
+                commnetsService.getCommentsInfoResultsOnPage(postId, pageNumber, limit);
 
         return ApiResponse.onSuccess(commentsInfoPageDto);
     }

--- a/src/main/java/com/example/HiBuddy/domain/comment/CommentsConverter.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/CommentsConverter.java
@@ -39,8 +39,10 @@ public class CommentsConverter {
                 .build();
     }
 
-    public static CommentsResponseDto.CommentsInfoPageDto toCommentsInfoResultPageDto(List<CommentsResponseDto.CommentDto> commentInfoDtoList, int totalPages, int totalElements,
-                                                                                       boolean isFirst, boolean isLast, int number, int numberOfElements) {
+    public static CommentsResponseDto.CommentsInfoPageDto toCommentsInfoResultPageDto(
+            List<CommentsResponseDto.CommentDto> commentInfoDtoList, int totalPages, int totalElements,
+            boolean isFirst, boolean isLast, int number, int numberOfElements) {
+
         return CommentsResponseDto.CommentsInfoPageDto.builder()
                 .comments(commentInfoDtoList)
                 .totalPages(totalPages)

--- a/src/main/java/com/example/HiBuddy/domain/comment/CommentsService.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/CommentsService.java
@@ -58,9 +58,9 @@ public class CommentsService {
 
     // 댓글 조회 API
     @Transactional(readOnly = true)
-    public CommentsResponseDto.CommentsInfoPageDto getCommentsInfoResultsOnPage(int page, int size) {
+    public CommentsResponseDto.CommentsInfoPageDto getCommentsInfoResultsOnPage(Long postId, int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
-        Page<Comments> commentsPage = commentsRepository.findAll(pageRequest);
+        Page<Comments> commentsPage = commentsRepository.findByPostId(postId, pageRequest);
 
         List<CommentsResponseDto.CommentDto> commentInfoDtoList = commentsPage.getContent().stream()
                 .map(comment -> {


### PR DESCRIPTION
# 수정 내용
- 댓글을 조회할 시 계속 같은 댓글이 조회되는 경우가 발생해 이를 수정하고자 다음과 같이 findByPostId의 레포지토리 메서드를 사용했습니다.
```java      
PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
Page<Comments> commentsPage = commentsRepository.findByPostId(postId, pageRequest);
```