### PR TITLE
[fix] GMT+9, UserDetails 삭제 

### DIFF
--- a/src/main/java/com/example/HiBuddy/domain/comment/CommentsController.java
+++ b/src/main/java/com/example/HiBuddy/domain/comment/CommentsController.java
@@ -51,7 +51,6 @@ public class CommentsController {
             @Parameter(name = "postId", description = "게시글의 id"),
     })
     public ApiResponse<CommentsResponseDto.CommentsInfoPageDto> getCommnetsInfoResultOnPage(
-            @AuthenticationPrincipal UserDetails user,
             @PathVariable Long postId,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int limit) {

--- a/src/main/java/com/example/HiBuddy/domain/post/PostsService.java
+++ b/src/main/java/com/example/HiBuddy/domain/post/PostsService.java
@@ -27,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -46,7 +48,11 @@ public class PostsService {
     public static String getCreatedAt(LocalDateTime createdAt) {
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS");
-        return createdAt.format(formatter);
+
+        // LocalDateTime을 ZoneDateTime으로 변환하고, GMT+9 타임존을 설정
+        ZonedDateTime zonedDateTime = createdAt.atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneId.of("Asia/Seoul"));
+
+        return zonedDateTime.format(formatter);
     }
 
     // 게시글 생성 메서드


### PR DESCRIPTION
# 수정 내용
- getCreatedAt의 메서드를 GMT+9로 수정했습니다.
- 댓글 조회의 UserDetails를 삭제했습니다. 